### PR TITLE
Update: Markdown rules and other improvements

### DIFF
--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -13,30 +13,20 @@
 	},
 	"tokenColors": [
 		{
-			"name": "Invisible",
-			"scope": "invisible",
-			"settings": {
-				"foreground": "#C5C8C6"
-			}
-		},
-		{
-			"name": "Comment | Ignore",
+			"name": "Keyword | Keyword Control | Storage Modifier | Source Tags | Meta Tag & Entity",
 			"scope": [
-				"comment",
-				"source.ignore"
+				"keyword",
+				"keyword.control",
+				"storage.modifier",
+				"source .entity.name.tag",
+				"source .entity.other.attribute-name",
+				"meta.tag.inline",
+				"meta.tag.inline .entity",
+				"meta.tag",
+				"meta.tag .entity"
 			],
 			"settings": {
-				"foreground": "#7C7C7C"
-			}
-		},
-		{
-			"name": "Entity | Selector CSS Punctuation",
-			"scope": [
-				"entity",
-				"meta.selector.css entity.other.attribute-name punctuation"
-			],
-			"settings": {
-				"foreground": "#FFD2A7"
+				"foreground": "#96CBFE"
 			}
 		},
 		{
@@ -64,35 +54,17 @@
 			}
 		},
 		{
-			"name": "Entity Inherited Class",
-			"scope": "entity.other.inherited-class",
-			"settings": {
-				"foreground": "#9B5C2E"
-			}
-		},
-		{
-			"name": "Keyword | Keyword Control | Storage Modifier | Source Tags | Meta Tag & Entity",
+			"name": "Doctype",
 			"scope": [
-				"keyword",
-				"keyword.control",
-				"storage.modifier",
-				"source .entity.name.tag",
-				"source .entity.other.attribute-name",
-				"meta.tag.inline",
-				"meta.tag.inline .entity",
-				"meta.tag",
-				"meta.tag .entity"
+				"meta.sgml.html meta.doctype",
+				".meta.sgml.html meta.doctype entity",
+				"meta.sgml.html meta.doctype string",
+				"meta.xml-processing",
+				"meta.xml-processing entity",
+				"meta.xml-processing string"
 			],
 			"settings": {
-				"foreground": "#96CBFE"
-			}
-		},
-		{
-			"name": "Selector CSS Entiry Name Tag",
-			"scope": "meta.selector.css entity.name.tag",
-			"settings": {
-				"foreground": "#96CBFE",
-				"fontStyle": "underline"
+				"foreground": "#494949"
 			}
 		},
 		{
@@ -121,6 +93,28 @@
 			}
 		},
 		{
+			"name": "String Constant | String Source Punctuation & Punctuation Source",
+			"scope": [
+				"string constant",
+				"source string punctuation.section.embedded",
+				"source string punctuation.section.embedded source"
+			],
+			"settings": {
+				"foreground": "#00A0A0"
+			}
+		},
+		{
+			"name": "String Regexp Exscaped or Embedded",
+			"scope": [
+				"string.regexp constant.character.escape",
+				"string.regexp source.ruby.embedded",
+				"string.regexp string.regexp.arbitrary-repitition"
+			],
+			"settings": {
+				"foreground": "#FF8000"
+			}
+		},
+		{
 			"name": "Constant | Support Constant",
 			"scope": [
 				"constant",
@@ -131,17 +125,23 @@
 			}
 		},
 		{
-			"name": "Constant Numeric",
-			"scope": "constant.numeric",
+			"name": "Comment | Ignore",
+			"scope": [
+				"comment",
+				"source.ignore"
+			],
 			"settings": {
-				"foreground": "#FF73FD"
+				"foreground": "#7C7C7C"
 			}
 		},
 		{
-			"name": "Variable",
-			"scope": "variable",
+			"name": "Entity | Selector CSS Punctuation",
+			"scope": [
+				"entity",
+				"meta.selector.css entity.other.attribute-name punctuation"
+			],
 			"settings": {
-				"foreground": "#C6C5FE"
+				"foreground": "#FFD2A7"
 			}
 		},
 		{
@@ -160,14 +160,89 @@
 			}
 		},
 		{
-			"name": "String Constant | String Source Punctuation & Punctuation Source",
+			"name": "Selector CSS Support Constant Property Value",
 			"scope": [
-				"string constant",
-				"source string punctuation.section.embedded",
-				"source string punctuation.section.embedded source"
+				"meta.property-group support.constant.property-value.css",
+				"meta.property-value support.constant.property-value.css"
 			],
 			"settings": {
-				"foreground": "#00A0A0"
+				"foreground": "#F9EE98"
+			}
+		},
+		{
+			"name": "Meta Diff, Diff Header",
+			"scope": [
+				"meta.diff",
+				"meta.diff.header"
+			],
+			"settings": {
+				"foreground": "#F8F8F8",
+			}
+		},
+		{
+			"name": "Source Tag and Attribute Namespace",
+			"scope": [
+				"entity.name.tag.namespace",
+				"entity.other.attribute-name.namespace"
+			],
+			"settings": {
+				"foreground": "#E18964"
+			}
+		},
+		{
+			"name": "CSS Constructor Argument | Selector CSS Pseudo-Class",
+			"scope": [
+				"meta.constructor.argument.css",
+				"meta.selector.css entity.other.attribute-name.pseudo-class"
+			],
+			"settings": {
+				"foreground": "#8F9D6A"
+			}
+		},
+		{
+			"name": "CSS Property value Support Constant, Named Color",
+			"scope": [
+				"meta.property-value support.constant.color.css",
+				"meta.property-value constant"
+			],
+			"settings": {
+				"foreground": "#87C38A"
+			}
+		},
+		{
+			"name": "Invisible",
+			"scope": "invisible",
+			"settings": {
+				"foreground": "#C5C8C6"
+			}
+		},
+		{
+			"name": "Entity Inherited Class",
+			"scope": "entity.other.inherited-class",
+			"settings": {
+				"foreground": "#9B5C2E"
+			}
+		},
+		{
+			"name": "Selector CSS Entiry Name Tag",
+			"scope": "meta.selector.css entity.name.tag",
+			"settings": {
+				"foreground": "#96CBFE",
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"name": "Constant Numeric",
+			"scope": "constant.numeric",
+			"settings": {
+				"foreground": "#FF73FD"
+			}
+		},
+		{
+			"name": "Variable",
+			"scope": "variable",
+			"settings": {
+				"foreground": "#C6C5FE"
 			}
 		},
 		{
@@ -182,17 +257,6 @@
 			"scope": "string.regexp",
 			"settings": {
 				"foreground": "#E9C062"
-			}
-		},
-		{
-			"name": "String Regexp Exscaped or Embedded",
-			"scope": [
-				"string.regexp constant.character.escape",
-				"string.regexp source.ruby.embedded",
-				"string.regexp string.regexp.arbitrary-repitition"
-			],
-			"settings": {
-				"foreground": "#FF8000"
 			}
 		},
 		{
@@ -231,16 +295,6 @@
 			}
 		},
 		{
-			"name": "Source Tag and Attribute Namespace",
-			"scope": [
-				"entity.name.tag.namespace",
-				"entity.other.attribute-name.namespace"
-			],
-			"settings": {
-				"foreground": "#E18964"
-			}
-		},
-		{
 			"name": "C Preprocessor",
 			"scope": [
 				"entity.name.function.preprocessor"
@@ -264,30 +318,6 @@
 			}
 		},
 		{
-			"name": "Doctype",
-			"scope": [
-				"meta.sgml.html meta.doctype",
-				".meta.sgml.html meta.doctype entity",
-				"meta.sgml.html meta.doctype string",
-				"meta.xml-processing",
-				"meta.xml-processing entity",
-				"meta.xml-processing string"
-			],
-			"settings": {
-				"foreground": "#494949"
-			}
-		},
-		{
-			"name": "CSS Constructor Argument | Selector CSS Pseudo-Class",
-			"scope": [
-				"meta.constructor.argument.css",
-				"meta.selector.css entity.other.attribute-name.pseudo-class"
-			],
-			"settings": {
-				"foreground": "#8F9D6A"
-			}
-		},
-		{
 			"name": "Selector CSS ID",
 			"scope": "meta.selector.css entity.other.attribute-name.id",
 			"settings": {
@@ -302,40 +332,10 @@
 			}
 		},
 		{
-			"name": "Selector CSS Support Constant Property Value",
-			"scope": [
-				"meta.property-group support.constant.property-value.css",
-				"meta.property-value support.constant.property-value.css"
-			],
-			"settings": {
-				"foreground": "#F9EE98"
-			}
-		},
-		{
 			"name": "Preprocessor At-Rule Keword Control",
 			"scope": "meta.preprocessor.at-rule keyword.control.at-rule",
 			"settings": {
 				"foreground": "#8693A5"
-			}
-		},
-		{
-			"name": "CSS Property value Support Constant, Named Color",
-			"scope": [
-				"meta.property-value support.constant.color.css",
-				"meta.property-value constant"
-			],
-			"settings": {
-				"foreground": "#87C38A"
-			}
-		},
-		{
-			"name": "Meta Diff, Diff Header",
-			"scope": [
-				"meta.diff",
-				"meta.diff.header"
-			],
-			"settings": {
-				"foreground": "#F8F8F8",
 			}
 		},
 		{

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -68,7 +68,7 @@
 				"source string source",
 				"source string meta.embedded.line",
 				"support.type.property-name.css",
-				"markup.list",
+				"markup.list"
 			],
 			"settings": {
 				"foreground": "#EDEDED"
@@ -109,10 +109,22 @@
 				"keyword.other.fn",
 				"entity.name.type.primitive",
 				"entity.name.type.numeric",
-				"fenced_code.block.language"
+				"fenced_code.block.language",
 			],
 			"settings": {
 				"foreground": "#CFCB90"
+			}
+		},
+		{
+			"name": "Entity | Selector CSS Punctuation",
+			"scope": [
+				"entity",
+				"entity.name.section",
+				"punctuation.definition.entity.css",
+				"meta.function-call.generic"
+			],
+			"settings": {
+				"foreground": "#FFD2A7"
 			}
 		},
 		{
@@ -158,7 +170,7 @@
 			}
 		},
 		{
-			"name": "Marukup Italics",
+			"name": "Markup Italics",
 			"scope": "markup.italic",
 			"settings": {
 				"foreground": "#8996A8",
@@ -199,36 +211,20 @@
 			}
 		},
 		{
-			"name": "Entity | Selector CSS Punctuation",
+			"name": "Selector CSS ID",
 			"scope": [
-				"entity",
-				"entity.name.section",
-				"meta.selector.css entity.other.attribute-name punctuation"
+				"entity.other.attribute-name.id",
+				"punctuation.definition.entity"
 			],
 			"settings": {
-				"foreground": "#FFD2A7"
-			}
-		},
-		{
-			"name": "Invalid Illegal",
-			"scope": "invalid.illegal",
-			"settings": {
-				"foreground": "#FD5FF1",
-			}
-		},
-		{
-			"name": "Invalid Deprecated",
-			"scope": "invalid.deprecated",
-			"settings": {
-				"foreground": "#FD5FF1",
-				"fontStyle": "underline"
+				"foreground": "#8B98AB"
 			}
 		},
 		{
 			"name": "Selector CSS Support Constant Property Value",
 			"scope": [
-				"meta.property-group support.constant.property-value.css",
-				"meta.property-value support.constant.property-value.css"
+				"meta.property-group",
+				"support.constant.property-value.css"
 			],
 			"settings": {
 				"foreground": "#F9EE98"
@@ -258,7 +254,7 @@
 			"name": "CSS Constructor Argument | Selector CSS Pseudo-Class",
 			"scope": [
 				"meta.constructor.argument.css",
-				"meta.selector.css entity.other.attribute-name.pseudo-class"
+				"entity.other.attribute-name.pseudo-class"
 			],
 			"settings": {
 				"foreground": "#8F9D6A"
@@ -267,8 +263,8 @@
 		{
 			"name": "CSS Property value Support Constant, Named Color",
 			"scope": [
-				"meta.property-value support.constant.color.css",
-				"meta.property-value constant"
+				"meta.property-value",
+				"support.constant.color.css"
 			],
 			"settings": {
 				"foreground": "#87C38A"
@@ -295,18 +291,49 @@
 			}
 		},
 		{
-			"name": "Entity Inherited Class",
-			"scope": "entity.other.inherited-class",
+			"name": "Preprocessor At-Rule Keword Control",
+			"scope": [
+				"meta.preprocessor.at-rule",
+				"keyword.control.at-rule"
+			],
 			"settings": {
-				"foreground": "#9B5C2E"
+				"foreground": "#8693A5"
+			}
+		},
+		{
+			"name": "Invalid Illegal",
+			"scope": "invalid.illegal",
+			"settings": {
+				"foreground": "#FD5FF1",
+			}
+		},
+		{
+			"name": "Invalid Deprecated",
+			"scope": "invalid.deprecated",
+			"settings": {
+				"foreground": "#FD5FF1",
+				"fontStyle": "underline"
 			}
 		},
 		{
 			"name": "Selector CSS Entiry Name Tag",
-			"scope": "meta.selector.css entity.name.tag",
+			"scope": "entity.name.tag",
 			"settings": {
-				"foreground": "#96CBFE",
-				"fontStyle": "underline"
+				"foreground": "#96CBFE"
+			}
+		},
+		{
+			"name": "Selector CSS Class",
+			"scope": "entity.other.attribute-name.class",
+			"settings": {
+				"foreground": "#62B1FE"
+			}
+		},
+		{
+			"name": "Entity Inherited Class",
+			"scope": "entity.other.inherited-class",
+			"settings": {
+				"foreground": "#9B5C2E"
 			}
 		},
 		{
@@ -327,7 +354,7 @@
 			"name": "String Regexp Group",
 			"scope": "string.regexp.group",
 			"settings": {
-				"foreground": "#C6A24F",
+				"foreground": "#C6A24F"
 			}
 		},
 		{
@@ -335,13 +362,6 @@
 			"scope": "string.regexp.character-class",
 			"settings": {
 				"foreground": "#B18A3D"
-			}
-		},
-		{
-			"name": "String Variable",
-			"scope": "string variable",
-			"settings": {
-				"foreground": "#8A9A95"
 			}
 		},
 		{
@@ -359,38 +379,10 @@
 			}
 		},
 		{
-			"name": "C Preprocessor Keyword",
-			"scope": "meta.preprocessor.c keyword",
-			"settings": {
-				"foreground": "#AFC4DB"
-			}
-		},
-		{
 			"name": "Cast",
 			"scope": "meta.cast",
 			"settings": {
 				"foreground": "#676767"
-			}
-		},
-		{
-			"name": "Selector CSS ID",
-			"scope": "meta.selector.css entity.other.attribute-name.id",
-			"settings": {
-				"foreground": "#8B98AB"
-			}
-		},
-		{
-			"name": "Selector CSS Class",
-			"scope": "meta.selector.css entity.other.attribute-name.class",
-			"settings": {
-				"foreground": "#62B1FE"
-			}
-		},
-		{
-			"name": "Preprocessor At-Rule Keword Control",
-			"scope": "meta.preprocessor.at-rule keyword.control.at-rule",
-			"settings": {
-				"foreground": "#8693A5"
 			}
 		},
 		{

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -23,7 +23,8 @@
 				"meta.tag.inline",
 				"meta.tag.inline .entity",
 				"meta.tag",
-				"meta.tag .entity"
+				"meta.tag .entity",
+				"markup.heading"
 			],
 			"settings": {
 				"foreground": "#96CBFE"
@@ -68,25 +69,39 @@
 			}
 		},
 		{
-			"name": "Keyword Operator | String Source, Source String Meta Embedded | Support Type Property-Name CSS",
+			"name": "Keyword Operator | String Source, Source String Meta Embedded | Support Type Property-Name CSS | Markup List",
 			"scope": [
 				"keyword.operator",
 				"punctuation.separator",
 				"source string source",
 				"source string meta.embedded.line",
-				"support.type.property-name.css"
+				"support.type.property-name.css",
+				"markup.list",
 			],
 			"settings": {
 				"foreground": "#EDEDED"
 			}
 		},
 		{
-			"name": "Storage | Primitives",
+			"name": "Markup Bold | Markup Quote Begin",
+			"scope": [
+				"markup.bold",
+				"punctuation.definition.quote.begin",
+				"meta.separator"
+			],
+			"settings": {
+				"foreground": "#EDEDED",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Storage | Primitives | Markup Fence Code Block Language",
 			"scope": [
 				"storage",
 				"keyword.type",
 				"entity.name.type.primitive",
-				"entity.name.type.numeric"
+				"entity.name.type.numeric",
+				"fenced_code.block.language"
 			],
 			"settings": {
 				"foreground": "#CFCB90"
@@ -115,29 +130,40 @@
 			}
 		},
 		{
-			"name": "Constant | Support Constant",
+			"name": "Constant | Support Constant | Markup Inline",
 			"scope": [
 				"constant",
 				"support.constant",
+				"markup.inline"
 			],
 			"settings": {
 				"foreground": "#99CC99"
 			}
 		},
 		{
-			"name": "Comment | Ignore",
+			"name": "Comment | Ignore | Markup Fence",
 			"scope": [
 				"comment",
-				"source.ignore"
+				"source.ignore",
+				"markup.fenced_code"
 			],
 			"settings": {
 				"foreground": "#7C7C7C"
 			}
 		},
 		{
+			"name": "Markup Strikethrough",
+			"scope": "markup.strikethrough",
+			"settings": {
+				"foreground": "#7C7C7C",
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
 			"name": "Entity | Selector CSS Punctuation",
 			"scope": [
 				"entity",
+				"entity.name.section",
 				"meta.selector.css entity.other.attribute-name punctuation"
 			],
 			"settings": {
@@ -210,8 +236,11 @@
 			}
 		},
 		{
-			"name": "Invisible",
-			"scope": "invisible",
+			"name": "Invisible | Markup Fenced Code",
+			"scope": [
+				"invisible",
+				"markup.fenced_code.block"
+			],
 			"settings": {
 				"foreground": "#C5C8C6"
 			}
@@ -239,15 +268,23 @@
 			}
 		},
 		{
-			"name": "Variable",
-			"scope": "variable",
+			"name": "Variable | Markup Quote",
+			"scope": [
+				"variable",
+				"markup.quote"
+			],
 			"settings": {
 				"foreground": "#C6C5FE"
 			}
 		},
 		{
-			"name": "String",
-			"scope": "string",
+			"name": "String | Link Title & Reference",
+			"scope": [
+				"string",
+				"string.other.link.title",
+				"string.other.link.description",
+				"constant.other.reference.link"
+			],
 			"settings": {
 				"foreground": "#A8FF60"
 			}
@@ -295,12 +332,22 @@
 			}
 		},
 		{
-			"name": "C Preprocessor",
+			"name": "C Preprocessor | Links",
 			"scope": [
-				"entity.name.function.preprocessor"
+				"entity.name.function.preprocessor",
+				"meta.link",
+				"markup.underline.link"
 			],
 			"settings": {
 				"foreground": "#8996A8"
+			}
+		},
+		{
+			"name": "Marukup Italics",
+			"scope": "markup.italic",
+			"settings": {
+				"foreground": "#8996A8",
+				"fontStyle": "italic"
 			}
 		},
 		{
@@ -336,13 +383,6 @@
 			"scope": "meta.preprocessor.at-rule keyword.control.at-rule",
 			"settings": {
 				"foreground": "#8693A5"
-			}
-		},
-		{
-			"name": "Meta Separator",
-			"scope": "meta.separator",
-			"settings": {
-				"foreground": "#60A633",
 			}
 		},
 		{

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -17,6 +17,8 @@
 			"scope": [
 				"keyword",
 				"keyword.control",
+				"keyword.operator.new",
+				"storage.type.class",
 				"storage.modifier",
 				"source .entity.name.tag",
 				"source .entity.other.attribute-name",
@@ -31,21 +33,14 @@
 			}
 		},
 		{
-			"name": "Entity Name Type Class & Struct",
-			"scope": [
-				"entity.name.type.class",
-				"entity.name.type.struct"
-			],
-			"settings": {
-				"foreground": "#FFFFB6",
-				"fontStyle": "underline"
-			}
-		},
-		{
-			"name": "Support | Entity Name | Type Name",
+			"name": "Support | Entity Name | Type Name | Type Storage",
 			"scope": [
 				"support",
 				"entity.name.type",
+				"entity.name.namespace",
+				"entity.name.scope-resolution",
+				"storage.modifier.import",
+				"storage.modifier.package",
 				"storage.type.object",
 				"storage.type.generic",
 				"storage.type.java"
@@ -55,17 +50,14 @@
 			}
 		},
 		{
-			"name": "Doctype",
+			"name": "Entity Name Type Class & Struct",
 			"scope": [
-				"meta.sgml.html meta.doctype",
-				".meta.sgml.html meta.doctype entity",
-				"meta.sgml.html meta.doctype string",
-				"meta.xml-processing",
-				"meta.xml-processing entity",
-				"meta.xml-processing string"
+				"entity.name.type.class",
+				"entity.name.type.struct"
 			],
 			"settings": {
-				"foreground": "#494949"
+				"foreground": "#FFFFB6",
+				"fontStyle": "underline"
 			}
 		},
 		{
@@ -83,9 +75,10 @@
 			}
 		},
 		{
-			"name": "Markup Bold | Markup Quote Begin",
+			"name": "Markup Bold | Markup List Begin | Markup Quote Begin",
 			"scope": [
 				"markup.bold",
+				"punctuation.definition.list.begin",
 				"punctuation.definition.quote.begin",
 				"meta.separator"
 			],
@@ -95,16 +88,81 @@
 			}
 		},
 		{
-			"name": "Storage | Primitives | Markup Fence Code Block Language",
+			"name": "Doctype",
+			"scope": [
+				"meta.sgml.html meta.doctype",
+				".meta.sgml.html meta.doctype entity",
+				"meta.sgml.html meta.doctype string",
+				"meta.xml-processing",
+				"meta.xml-processing entity",
+				"meta.xml-processing string"
+			],
+			"settings": {
+				"foreground": "#494949"
+			}
+		},
+		{
+			"name": "Function Storage | Primitives | Markup Fence Code Block Language",
 			"scope": [
 				"storage",
 				"keyword.type",
+				"keyword.other.fn",
 				"entity.name.type.primitive",
 				"entity.name.type.numeric",
 				"fenced_code.block.language"
 			],
 			"settings": {
 				"foreground": "#CFCB90"
+			}
+		},
+		{
+			"name": "Comment | Ignore | Markup Fence",
+			"scope": [
+				"comment",
+				"source.ignore",
+				"markup.fenced_code"
+			],
+			"settings": {
+				"foreground": "#7C7C7C"
+			}
+		},
+		{
+			"name": "Markup Strikethrough",
+			"scope": "markup.strikethrough",
+			"settings": {
+				"foreground": "#7C7C7C",
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"name": "String | Link Title & Reference",
+			"scope": [
+				"string",
+				"string.other.link.title",
+				"string.other.link.description",
+				"constant.other.reference.link"
+			],
+			"settings": {
+				"foreground": "#A8FF60"
+			}
+		},
+		{
+			"name": "C Preprocessor | Links",
+			"scope": [
+				"entity.name.function.preprocessor",
+				"meta.link",
+				"markup.underline.link"
+			],
+			"settings": {
+				"foreground": "#8996A8"
+			}
+		},
+		{
+			"name": "Marukup Italics",
+			"scope": "markup.italic",
+			"settings": {
+				"foreground": "#8996A8",
+				"fontStyle": "italic"
 			}
 		},
 		{
@@ -138,25 +196,6 @@
 			],
 			"settings": {
 				"foreground": "#99CC99"
-			}
-		},
-		{
-			"name": "Comment | Ignore | Markup Fence",
-			"scope": [
-				"comment",
-				"source.ignore",
-				"markup.fenced_code"
-			],
-			"settings": {
-				"foreground": "#7C7C7C"
-			}
-		},
-		{
-			"name": "Markup Strikethrough",
-			"scope": "markup.strikethrough",
-			"settings": {
-				"foreground": "#7C7C7C",
-				"fontStyle": "strikethrough"
 			}
 		},
 		{
@@ -246,6 +285,16 @@
 			}
 		},
 		{
+			"name": "Variable | Markup Quote",
+			"scope": [
+				"variable",
+				"markup.quote"
+			],
+			"settings": {
+				"foreground": "#C6C5FE"
+			}
+		},
+		{
 			"name": "Entity Inherited Class",
 			"scope": "entity.other.inherited-class",
 			"settings": {
@@ -265,28 +314,6 @@
 			"scope": "constant.numeric",
 			"settings": {
 				"foreground": "#FF73FD"
-			}
-		},
-		{
-			"name": "Variable | Markup Quote",
-			"scope": [
-				"variable",
-				"markup.quote"
-			],
-			"settings": {
-				"foreground": "#C6C5FE"
-			}
-		},
-		{
-			"name": "String | Link Title & Reference",
-			"scope": [
-				"string",
-				"string.other.link.title",
-				"string.other.link.description",
-				"constant.other.reference.link"
-			],
-			"settings": {
-				"foreground": "#A8FF60"
 			}
 		},
 		{
@@ -329,25 +356,6 @@
 			"scope": "entity.other.attribute-name",
 			"settings": {
 				"foreground": "#FFD7B1"
-			}
-		},
-		{
-			"name": "C Preprocessor | Links",
-			"scope": [
-				"entity.name.function.preprocessor",
-				"meta.link",
-				"markup.underline.link"
-			],
-			"settings": {
-				"foreground": "#8996A8"
-			}
-		},
-		{
-			"name": "Marukup Italics",
-			"scope": "markup.italic",
-			"settings": {
-				"foreground": "#8996A8",
-				"fontStyle": "italic"
 			}
 		},
 		{

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -1,28 +1,22 @@
 {
 	"type": "dark",
 	"colors": {
-		"editor.background": "#1d1f21",
-		"editor.foreground": "#c5c8c6",
+		"editor.background": "#1D1F21",
+		"editor.foreground": "#C5C8C6",
 		"editor.selectionBackground": "#444444",
-		"editor.lineHighlightBackground": "#3a3a3a",
-		"editorCursor.foreground": "#a5a2a2",
-		"editorWhitespace.foreground": "#c5c8c6",
+		"editor.lineHighlightBackground": "#3A3A3A",
+		"editorCursor.foreground": "#A5A2A2",
+		"editorWhitespace.foreground": "#C5C8C6",
 		"editorIndentGuide.background": "#474747",
-		"statusBar.background": "#3382c7",
-		"activityBarBadge.background": "#60a633"
+		"statusBar.background": "#3382C7",
+		"activityBarBadge.background": "#60A633"
 	},
 	"tokenColors": [
-		{
-			"settings": {
-				"foreground": "#c5c8c6ff",
-				"background": "#1d1f21ff"
-			}
-		},
 		{
 			"name": "Invisible",
 			"scope": "invisible",
 			"settings": {
-				"foreground": "#c5c8c6"
+				"foreground": "#C5C8C6"
 			}
 		},
 		{
@@ -401,25 +395,25 @@
 		{
 			"scope": "token.info-token",
 			"settings": {
-				"foreground": "#6796e6"
+				"foreground": "#6796E6"
 			}
 		},
 		{
 			"scope": "token.warn-token",
 			"settings": {
-				"foreground": "#cd9731"
+				"foreground": "#CD9731"
 			}
 		},
 		{
 			"scope": "token.error-token",
 			"settings": {
-				"foreground": "#f44747"
+				"foreground": "#F44747"
 			}
 		},
 		{
 			"scope": "token.debug-token",
 			"settings": {
-				"foreground": "#b267e6"
+				"foreground": "#B267E6"
 			}
 		}
 	]

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -123,7 +123,6 @@
 			"scope": "invalid.illegal",
 			"settings": {
 				"foreground": "#FD5FF1",
-				"background": "#A95AA9"
 			}
 		},
 		{
@@ -131,7 +130,6 @@
 			"scope": "invalid.illegal",
 			"settings": {
 				"foreground": "#FD5FF1",
-				"background": "#A95AA9"
 			}
 		},
 		{
@@ -195,7 +193,6 @@
 			"scope": "string.regexp.group",
 			"settings": {
 				"foreground": "#C6A24F",
-				"background": "#595f65"
 			}
 		},
 		{
@@ -392,7 +389,6 @@
 			],
 			"settings": {
 				"foreground": "#F8F8F8",
-				"background": "#0E2231"
 			}
 		},
 		{
@@ -400,7 +396,6 @@
 			"scope": "meta.separator",
 			"settings": {
 				"foreground": "#60A633",
-				"background": "#242424"
 			}
 		},
 		{

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -20,8 +20,11 @@
 			}
 		},
 		{
-			"name": "Comment",
-			"scope": "comment",
+			"name": "Comment | Ignore",
+			"scope": [
+				"comment",
+				"source.ignore"
+			],
 			"settings": {
 				"foreground": "#7C7C7C"
 			}
@@ -37,16 +40,25 @@
 			}
 		},
 		{
-			"name": "Entity Name Type",
-			"scope": "entity.name.type",
+			"name": "Entity Name Type Class & Struct",
+			"scope": [
+				"entity.name.type.class",
+				"entity.name.type.struct"
+			],
 			"settings": {
 				"foreground": "#FFFFB6",
 				"fontStyle": "underline"
 			}
 		},
 		{
-			"name": "Support",
-			"scope": "support",
+			"name": "Support | Entity Name | Type Name",
+			"scope": [
+				"support",
+				"entity.name.type",
+				"storage.type.object",
+				"storage.type.generic",
+				"storage.type.java"
+			],
 			"settings": {
 				"foreground": "#FFFFB6"
 			}
@@ -87,6 +99,7 @@
 			"name": "Keyword Operator | String Source, Source String Meta Embedded | Support Type Property-Name CSS",
 			"scope": [
 				"keyword.operator",
+				"punctuation.separator",
 				"source string source",
 				"source string meta.embedded.line",
 				"support.type.property-name.css"
@@ -96,8 +109,13 @@
 			}
 		},
 		{
-			"name": "Storage",
-			"scope": "storage",
+			"name": "Storage | Primitives",
+			"scope": [
+				"storage",
+				"keyword.type",
+				"entity.name.type.primitive",
+				"entity.name.type.numeric"
+			],
 			"settings": {
 				"foreground": "#CFCB90"
 			}
@@ -106,7 +124,7 @@
 			"name": "Constant | Support Constant",
 			"scope": [
 				"constant",
-				"support.constant"
+				"support.constant",
 			],
 			"settings": {
 				"foreground": "#99CC99"
@@ -224,7 +242,9 @@
 		},
 		{
 			"name": "C Preprocessor",
-			"scope": "meta.preprocessor.c",
+			"scope": [
+				"entity.name.function.preprocessor"
+			],
 			"settings": {
 				"foreground": "#8996A8"
 			}

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -27,10 +27,9 @@
 			}
 		},
 		{
-			"name": "Entity | Support Constant | Selector CSS Punctuation",
+			"name": "Entity | Selector CSS Punctuation",
 			"scope": [
 				"entity",
-				"support.constant",
 				"meta.selector.css entity.other.attribute-name punctuation"
 			],
 			"settings": {
@@ -104,8 +103,11 @@
 			}
 		},
 		{
-			"name": "Constant",
-			"scope": "constant",
+			"name": "Constant | Support Constant",
+			"scope": [
+				"constant",
+				"support.constant"
+			],
 			"settings": {
 				"foreground": "#99CC99"
 			}

--- a/themes/Atom Dark Syntax-color-theme.json
+++ b/themes/Atom Dark Syntax-color-theme.json
@@ -27,8 +27,12 @@
 			}
 		},
 		{
-			"name": "Entity",
-			"scope": "entity",
+			"name": "Entity | Support Constant | Selector CSS Punctuation",
+			"scope": [
+				"entity",
+				"support.constant",
+				"meta.selector.css entity.other.attribute-name punctuation"
+			],
 			"settings": {
 				"foreground": "#FFD2A7"
 			}
@@ -42,6 +46,13 @@
 			}
 		},
 		{
+			"name": "Support",
+			"scope": "support",
+			"settings": {
+				"foreground": "#FFFFB6"
+			}
+		},
+		{
 			"name": "Entity Inherited Class",
 			"scope": "entity.other.inherited-class",
 			"settings": {
@@ -49,22 +60,38 @@
 			}
 		},
 		{
-			"name": "Keyword",
-			"scope": "keyword",
+			"name": "Keyword | Keyword Control | Storage Modifier | Source Tags | Meta Tag & Entity",
+			"scope": [
+				"keyword",
+				"keyword.control",
+				"storage.modifier",
+				"source .entity.name.tag",
+				"source .entity.other.attribute-name",
+				"meta.tag.inline",
+				"meta.tag.inline .entity",
+				"meta.tag",
+				"meta.tag .entity"
+			],
 			"settings": {
 				"foreground": "#96CBFE"
 			}
 		},
 		{
-			"name": "Keyword Control",
-			"scope": "keyword.control",
+			"name": "Selector CSS Entiry Name Tag",
+			"scope": "meta.selector.css entity.name.tag",
 			"settings": {
-				"foreground": "#96CBFE"
+				"foreground": "#96CBFE",
+				"fontStyle": "underline"
 			}
 		},
 		{
-			"name": "Keyword Operator",
-			"scope": "keyword.operator",
+			"name": "Keyword Operator | String Source, Source String Meta Embedded | Support Type Property-Name CSS",
+			"scope": [
+				"keyword.operator",
+				"source string source",
+				"source string meta.embedded.line",
+				"support.type.property-name.css"
+			],
 			"settings": {
 				"foreground": "#EDEDED"
 			}
@@ -74,13 +101,6 @@
 			"scope": "storage",
 			"settings": {
 				"foreground": "#CFCB90"
-			}
-		},
-		{
-			"name": "Storage Modifier",
-			"scope": "storage.modifier",
-			"settings": {
-				"foreground": "#96CBFE"
 			}
 		},
 		{
@@ -105,6 +125,13 @@
 			}
 		},
 		{
+			"name": "Invalid Illegal",
+			"scope": "invalid.illegal",
+			"settings": {
+				"foreground": "#FD5FF1",
+			}
+		},
+		{
 			"name": "Invalid Deprecated",
 			"scope": "invalid.deprecated",
 			"settings": {
@@ -113,39 +140,12 @@
 			}
 		},
 		{
-			"name": "Invalid Illegal",
-			"scope": "invalid.illegal",
-			"settings": {
-				"foreground": "#FD5FF1",
-			}
-		},
-		{
-			"name": "Invalid Illegal",
-			"scope": "invalid.illegal",
-			"settings": {
-				"foreground": "#FD5FF1",
-			}
-		},
-		{
-			"name": "String Source, Source String Meta Embedded",
+			"name": "String Constant | String Source Punctuation & Punctuation Source",
 			"scope": [
-				"source string source",
-				"source string meta.embedded.line"
+				"string constant",
+				"source string punctuation.section.embedded",
+				"source string punctuation.section.embedded source"
 			],
-			"settings": {
-				"foreground": "#EDEDED"
-			}
-		},
-		{
-			"name": "String Source Punctuation",
-			"scope": "source string punctuation.section.embedded",
-			"settings": {
-				"foreground": "#00A0A0"
-			}
-		},
-		{
-			"name": "String Source Punctuation Source",
-			"scope": "source string punctuation.section.embedded source",
 			"settings": {
 				"foreground": "#00A0A0"
 			}
@@ -155,13 +155,6 @@
 			"scope": "string",
 			"settings": {
 				"foreground": "#A8FF60"
-			}
-		},
-		{
-			"name": "String Constant",
-			"scope": "string constant",
-			"settings": {
-				"foreground": "#00A0A0"
 			}
 		},
 		{
@@ -204,43 +197,10 @@
 			}
 		},
 		{
-			"name": "Support",
-			"scope": "support",
-			"settings": {
-				"foreground": "#FFFFB6"
-			}
-		},
-		{
 			"name": "Support Function",
 			"scope": "support.function",
 			"settings": {
 				"foreground": "#DAD085"
-			}
-		},
-		{
-			"name": "Support Constant",
-			"scope": "support.constant",
-			"settings": {
-				"foreground": "#FFD2A7"
-			}
-		},
-		{
-			"name": "Support Type Property-Name CSS",
-			"scope": "support.type.property-name.css",
-			"settings": {
-				"foreground": "#EDEDED"
-			}
-		},
-		{
-			"name": "Source Tags",
-			"scope": [
-				"source .entity.name.tag",
-				"source .entity.other.attribute-name",
-				"meta.tag.inline",
-				"meta.tag.inline .entity"
-			],
-			"settings": {
-				"foreground": "#96CBFE"
 			}
 		},
 		{
@@ -296,26 +256,11 @@
 			}
 		},
 		{
-			"name": "Meta Tag, Entity",
+			"name": "CSS Constructor Argument | Selector CSS Pseudo-Class",
 			"scope": [
-				"meta.tag",
-				"meta.tag .entity"
+				"meta.constructor.argument.css",
+				"meta.selector.css entity.other.attribute-name.pseudo-class"
 			],
-			"settings": {
-				"foreground": "#96CBFE"
-			}
-		},
-		{
-			"name": "Selector CSS Entiry Name Tag",
-			"scope": "meta.selector.css entity.name.tag",
-			"settings": {
-				"foreground": "#96CBFE",
-				"fontStyle": "underline"
-			}
-		},
-		{
-			"name": "Selector CSS Pseudo-Class",
-			"scope": "meta.selector.css entity.other.attribute-name.pseudo-class",
 			"settings": {
 				"foreground": "#8F9D6A"
 			}
@@ -332,13 +277,6 @@
 			"scope": "meta.selector.css entity.other.attribute-name.class",
 			"settings": {
 				"foreground": "#62B1FE"
-			}
-		},
-		{
-			"name": "Selector CSS punctuation",
-			"scope": "meta.selector.css entity.other.attribute-name punctuation",
-			"settings": {
-				"foreground": "#FFD2A7"
 			}
 		},
 		{
@@ -366,13 +304,6 @@
 			],
 			"settings": {
 				"foreground": "#87C38A"
-			}
-		},
-		{
-			"name": "CSS Constructor Argument",
-			"scope": "meta.constructor.argument.css",
-			"settings": {
-				"foreground": "#8F9D6A"
 			}
 		},
 		{


### PR DESCRIPTION
This is one of my favorite themes! However, it was lacking some rules for Markdown. I made the following updates:

1. Removed duplicate or unused rules
2. Removed keys with warnings
3. Grouped rules by color and sorted them by number of rules per color
4. Tried to make colors consistent across multiple languages by using https://github.com/TheRenegadeCoder/sample-programs as my test repository
5. Tried to maintain most of the original theme's scopes, especially with JS, HTML, & CSS
6. Got CSS to look consistent with SCSS (had to remove some underlines, the rendering was looking really weird)
7. Added rules for Markdown

The colors I used for the Markdown don't match that of Atom, but Atom's was pretty minimal as well. I tried my best to make it look like it belongs to the theme, but feel free to make any changes if you feel it would look better.

![Screenshot from 2023-06-03 15-18-36](https://github.com/jack-pallot/vscode-atom-dark-syntax/assets/7450202/12222e99-1e2a-4413-811d-e25171bad118)

